### PR TITLE
Add ClientAuth check and fix some errors

### DIFF
--- a/pxethief.py
+++ b/pxethief.py
@@ -220,10 +220,13 @@ def get_variable_file_path(tftp_server):
     encrypted_key = None
     if ans:
         packet = ans
-        dhcp_options = packet[1][DHCP].options
+        dhcp_options = packet[0][DHCP].options
     
         #Does the received packet contain DHCP Option 243? DHCP option 243 is used by SCCM to send the variable file location
-        option_number, variables_file = next(opt for opt in dhcp_options if isinstance(opt, tuple) and opt[0] == 243) 
+        try:
+            option_number, variables_file = next(opt for opt in dhcp_options if isinstance(opt, tuple) and opt[0] == 243) 
+        except:
+            variables_file = None
         if variables_file:
             packet_type = variables_file[0] #First byte of the option data determines the type of data that follows
             data_length = variables_file[1] #Second byte of the option data is the length of data that follows

--- a/pxethief.py
+++ b/pxethief.py
@@ -177,7 +177,7 @@ def find_pxe_server():
         packet = ans
 
         # Pull out DHCP offer from received answer packet
-        dhcp_options = packet[1][DHCP].options
+        dhcp_options = packet[0][DHCP].options
         
         tftp_server = next((opt[1] for opt in dhcp_options if isinstance(opt, tuple) and opt[0] == "tftp_server_name"),None)
         if tftp_server:

--- a/pxethief.py
+++ b/pxethief.py
@@ -495,19 +495,30 @@ def dowload_and_decrypt_policies_using_certificate(guid,cert_bytes):
 
     data = CCMClientID.encode("utf-16-le") + b'\x00\x00'
     #CCMClientIDSignature = generateSignedData(data,cryptoProv)
-    CCMClientIDSignature = str(generateClientTokenSignature(data,cryptoProv))
+    try:
+        CCMClientIDSignature = str(generateClientTokenSignature(data,cryptoProv))
+    except:
+        print("[+] Error generating SHA256 CCMClientIDSignature - Trying SHA1...")
+        CCMClientIDSignature = generateSignedData(data,cryptoProv)
     print("[+] CCMClientID Signature Generated")
 
     CCMClientTimestamp = datetime.datetime.utcnow().replace(microsecond=0).isoformat()+'Z'
     data = CCMClientTimestamp.encode("utf-16-le") + b'\x00\x00'
     #CCMClientTimestampSignature = generateSignedData(data,cryptoProv)
-    CCMClientTimestampSignature = str(generateClientTokenSignature(data,cryptoProv))
+    try:
+        CCMClientTimestampSignature = str(generateClientTokenSignature(data,cryptoProv))
+    except:
+        print("[+] Error generating SHA256 CCMClientTimestampSignature - Trying SHA1...")
+        CCMClientTimestampSignature = generateSignedData(data,cryptoProv)
     print("[+] CCMClientTimestamp Signature Generated")
 
     data = (CCMClientID + ';' + CCMClientTimestamp + "\0").encode("utf-16-le")
     #clientTokenSignature = str(generateSignedData(data,cryptoProv))
-    clientTokenSignature = str(generateClientTokenSignature(data,cryptoProv))
-    
+    try:
+        clientTokenSignature = str(generateClientTokenSignature(data,cryptoProv))
+    except:
+        print("[+] Error generating SHA256 clientTokenSignature - Trying SHA1...")
+        clientTokenSignature = str(generateSignedData(data,cryptoProv))
     print("[+] ClientToken Signature Generated")
     
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests-toolbelt>=0.9.1
 pywin32>=303
 pycryptodome>=3.14.1
 lxml>=4.9.1
+cryptography>=43.0.1


### PR DESCRIPTION
This PR is mainly about adding the ability to check if the retrieved certificate allow client-auth (see #8)
![Sans titre](https://github.com/user-attachments/assets/005507b3-50f3-4282-9350-bf1f81d50a99)

And some fix (checked both in PKI mode and Default mode) :
- Changed packet[1][DHCP].options to packet[0][DHCP].options because i got errors in some configurations
- Added try blocks in order to fallback to sha1 when sha256 isnt available
- Handled error message when dhcp options 243 is not found